### PR TITLE
Revert "Bump highlight.js from 9.15.10 to 9.18.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,9 +2484,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA=="
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha1-exjtdckDSMBF7vntCMoTGaIhmtI="
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",


### PR DESCRIPTION
Reverts uestc-fury/uestc-fury.github.io#3